### PR TITLE
CM-447: deduplication logic on task resolve

### DIFF
--- a/deduplication/services.py
+++ b/deduplication/services.py
@@ -210,9 +210,15 @@ def _update_instance_json_ext_if_different_value(instance, json_ext_kwargs, user
     if json_ext_kwargs:
         json_ext = instance.json_ext or {}
         for key, value in json_ext_kwargs.items():
-            if json_ext.get(key) != value:
+            current_value = json_ext.get(key)
+            if not current_value and not value:
+                continue
+            if current_value != value:
                 is_instance_updated = True
-                json_ext[key] = value
+                if value:
+                    json_ext[key] = value
+                else:
+                    del json_ext[key]
         instance.json_ext = json_ext
         if is_instance_updated:
             instance.save(username=user.username)

--- a/deduplication/signals/__init__.py
+++ b/deduplication/signals/__init__.py
@@ -1,11 +1,11 @@
 from core.service_signals import ServiceSignalBindType
 from core.signals import bind_service_signal
-from deduplication.services import on_deduplication_task_complete_service_handler, CreateDeduplicationReviewTasksService
+from deduplication.services import on_deduplication_task_complete_service_handler
 
 
 def bind_service_signals():
     bind_service_signal(
         'task_service.complete_task',
-        on_deduplication_task_complete_service_handler(CreateDeduplicationReviewTasksService),
+        on_deduplication_task_complete_service_handler(),
         bind_type=ServiceSignalBindType.AFTER
     )

--- a/deduplication/signals/__init__.py
+++ b/deduplication/signals/__init__.py
@@ -6,6 +6,6 @@ from deduplication.services import on_deduplication_task_complete_service_handle
 def bind_service_signals():
     bind_service_signal(
         'task_service.complete_task',
-        on_deduplication_task_complete_service_handler(),
+        on_deduplication_task_complete_service_handler,
         bind_type=ServiceSignalBindType.AFTER
     )

--- a/deduplication/validations.py
+++ b/deduplication/validations.py
@@ -1,0 +1,95 @@
+import json
+
+from django.db.models import Q
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+from social_protection.models import Beneficiary
+from tasks_management.models import Task
+
+
+class CreateDeduplicationReviewTasksValidation:
+    @classmethod
+    def validate_create_deduplication_task(cls, task_data, service_name):
+        errors = cls.get_errors_deduplication_task_data(task_data, service_name)
+        if errors:
+            raise ValidationError(errors)
+
+    @classmethod
+    def get_errors_deduplication_task_data(cls, task_data, service_name):
+        count = task_data.get("count")
+        ids = task_data.get("ids")
+        column_values = task_data.get("column_values")
+
+        errors = [
+            *cls._validate_arg_existence(
+                count,
+                "deduplication.validations.CreateDeduplicationReviewTasksValidation.count_missing"),
+            *cls._validate_arg_existence(
+                ids,
+                "deduplication.validations.CreateDeduplicationReviewTasksValidation.ids_missing"),
+            *cls._validate_arg_existence(
+                column_values,
+                "deduplication.validations.CreateDeduplicationReviewTasksValidation.column_values_missing")
+        ]
+
+        not_existing_ids = cls._validate_existence_of_beneficiary(ids)
+        beneficiary_in_task = cls._validate_beneficiary_already_in_task(ids, service_name)
+
+        errors.extend(
+            [
+                *cls._validate_no_errors(
+                    not_existing_ids,
+                    "deduplication.validations.CreateDeduplicationReviewTasksValidation.not_existing_ids",
+                    "ids"
+                ),
+                *cls._validate_no_errors(
+                    beneficiary_in_task,
+                    "deduplication.validations.CreateDeduplicationReviewTasksValidation.beneficiary_in_task",
+                    "beneficiaries"
+                )
+            ]
+        )
+
+        return errors
+
+    @classmethod
+    def _validate_arg_existence(cls, kwarg, error_message_id):
+        if not kwarg:
+            return [{"message": _(error_message_id)}]
+        return []
+
+    @classmethod
+    def _validate_no_errors(cls, errors, error_message_id, dict_key):
+        if errors:
+            return [{"message": _(error_message_id) % {dict_key: json.dumps(errors)}}]
+        return []
+
+    @classmethod
+    def _validate_existence_of_beneficiary(cls, ids):
+        not_existing_ids = []
+        for beneficiary_id in ids:
+            if not Beneficiary.objects.filter(id=beneficiary_id).exists():
+                not_existing_ids.append(beneficiary_id)
+        return not_existing_ids
+
+    @classmethod
+    def _validate_beneficiary_already_in_task(cls, ids, service_name):
+        beneficiary_in_task = {}
+        status_accepted = Task.Status.ACCEPTED
+        status_received = Task.Status.RECEIVED
+
+        filters = [
+            Q(is_deleted=False),
+            Q(status=status_accepted) | Q(status=status_received),
+            Q(source=service_name),
+        ]
+        task_queryset = Task.objects.filter(*filters)
+
+        for beneficiary_id in ids:
+            tmp_task_queryset = task_queryset
+            if tmp_task_queryset.filter(data__ids__contains=beneficiary_id).exists():
+                beneficiary = Beneficiary.objects.get(id=beneficiary_id)
+                beneficiary_in_task[beneficiary_id] = beneficiary.individual.__str__()
+
+        return beneficiary_in_task

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,14 @@
+msgid "deduplication.validations.CreateDeduplicationReviewTasksValidation.count_missing"
+msgstr "Count missing in task data."
+
+msgid "deduplication.validations.CreateDeduplicationReviewTasksValidation.ids_missing"
+msgstr "Ids missing in task data."
+
+msgid "deduplication.validations.CreateDeduplicationReviewTasksValidation.column_values_missing"
+msgstr "Column values missing in task data."
+
+msgid "deduplication.validations.CreateDeduplicationReviewTasksValidation.not_existing_ids"
+msgstr "No beneficiaries for ids: %(ids)"
+
+msgid "deduplication.validations.CreateDeduplicationReviewTasksValidation.beneficiary_in_task"
+msgstr "Beneficiaries: %(beneficiaries) already in deduplication task."


### PR DESCRIPTION
https://openimis.atlassian.net/browse/CM-447

It needs: https://github.com/openimis/openimis-be-tasks_management_py/pull/48

It only marks Beneficiaries as deleted. It does not delete Individual records as I believe we will have separate task for Individual deduplication. It would not be a good idea to delete Individuals here since they might be in different BenefitPlans. However it still updates individual data such as name, last name and date of birth if selected. Shouldn't it be limited to just benefit plan data schema?